### PR TITLE
Optimize GitHub build action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'oracle'
           java-version: '17'
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,16 +9,16 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '17'
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Gradle and execute check task
@@ -27,5 +27,6 @@ jobs:
         with:
           # Only write to the cache for builds on the 'main' branch.
           # Builds on other branches will only read existing entries from the cache.
+          gradle-home-cache-cleanup: true
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           arguments: check --scan


### PR DESCRIPTION
- Run  `setup-java` action before `checkout` action (should improve caching as the output of setup java changes less often than checkout repo)
- Set `gradle-home-cache-cleanup: true` to avoid gradle dir to grow indefinietely
- Use `ubuntu-latest`
- Use oracle jdk