### PR TITLE
GitHub Actions: use MacOS runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 120
     steps:
       - name: Setup Java


### PR DESCRIPTION
macOS hosted runners have more cores and more ram and allow graphics HW acceleration.
See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources